### PR TITLE
BUG-DAPR-671: update input validation to account for variables with digits

### DIFF
--- a/compare_expressions.go
+++ b/compare_expressions.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 )
+
 /**
 This is the main function that is to be called to verify if 2 expressions are duplicate or not.
 
@@ -20,7 +21,7 @@ operators                           ----  && ||
 comparators                         ----  ==
 values or right side of expressions ----  to be binary only. So it can be 1 or 0
 attribute or left side of expression ---- can be any valid string name
- */
+*/
 func CheckIfDuplicateExpressions(expr1 string, expr2 string) (bool, error) {
 	parameters, err := ValidateInput(expr1, expr2)
 	if err != nil {
@@ -54,7 +55,7 @@ This function is to validate the input in the following way.
 Example:
 parameters:  expr1 a == 1 && b == 1,expr1 b == 1 && a == 1   return: ["a","b"], nil
 parameters:  expr1 a == 1 && b == 1,expr1 b == 1 && a == 1 and c == 1  "expressions have different number of parameters"
- */
+*/
 func ValidateInput(expr1, expr2 string) ([]string, error) {
 	params1, err := ValidateFormat(expr1)
 	if err != nil {
@@ -77,10 +78,9 @@ func ValidateInput(expr1, expr2 string) ([]string, error) {
 	return params1, nil
 }
 
-
 /**
 This function filters the duplicates from given array of string
- */
+*/
 func FilterDuplicates(params []string) []string {
 	parametersMap := make(map[string]interface{})
 	list := []string{}
@@ -102,17 +102,15 @@ operators                           ----  && ||
 comparators                         ----  ==
 values or right side of expressions ----  to be binary only. So it can be 1 or 0
 attribute or left side of expression ---- can be any valid string name
- */
+*/
 func ValidateFormat(expr string) ([]string, error) {
 	regex := regexp.MustCompile(`\s*[=]{2}?\s*[1|0]`)
 	replaceExpr := regex.ReplaceAllString(expr, " ")
 	result := strings.Fields(replaceExpr)
 
-
-	equalsFound := strings.Contains(replaceExpr, "=")
-	onesFound := strings.Contains(replaceExpr, "1")
-	zeroesFound := strings.Contains(replaceExpr, "0")
-	if equalsFound || onesFound || zeroesFound {
+	invalidRegex := regexp.MustCompile(`\s+[1.0.=]{1}\s*`)
+	invalidExpr := invalidRegex.MatchString(replaceExpr)
+	if invalidExpr {
 		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))
 	}
 
@@ -144,7 +142,7 @@ func ValidateFormat(expr string) ([]string, error) {
 
 /**
 This function checks whether all strings present in params2 is contained in params1
- */
+*/
 func ListContains(params1, params2 []string) error {
 	if len(params1) != len(params2) {
 		return errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", params1, params2))
@@ -167,7 +165,7 @@ func ListContains(params1, params2 []string) error {
 /**
 This function generates the truth table for the given expression and set of parameters present in the expression.
 It used tail recursion to evaluate expression for all possible values to the set of parameters.
- */
+*/
 func GenerateTruthTable(expr string, parameters []string, parametersMap map[string]interface{}, index int, count *[]bool) error {
 	if index == len(parameters) {
 		result, err := EvaluateExpression(expr, parametersMap)
@@ -196,7 +194,7 @@ func GenerateTruthTable(expr string, parameters []string, parametersMap map[stri
 
 /**
 This function uses govaluate library to evaluate the provided boolean expression
- */
+*/
 func EvaluateExpression(expr string, parameters map[string]interface{}) (interface{}, error) {
 	expression, err := govaluate.NewEvaluableExpression(expr)
 	if err != nil {
@@ -208,4 +206,3 @@ func EvaluateExpression(expr string, parameters map[string]interface{}) (interfa
 	}
 	return result, nil
 }
-

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -14,20 +14,24 @@ func TestValidateFormat(t *testing.T) {
 		result []string
 		err    error
 	}{
+
 		{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
 		{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
 		{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
 		{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
 		{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
 
+		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1 )", []string{"a-1", "b-0"}, nil},
+		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
+		{"success_when_pair_digits_in_variable", "(a_18_04 == 1 && b_20_10 == 1 )", []string{"a_18_04", "b_20_10"}, nil},
 
 		{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
 		{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
 		{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
 
-		{"error_when_invalid_format_equals", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_ones", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_zeroes", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
 
 		{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
 		{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
@@ -35,7 +39,10 @@ func TestValidateFormat(t *testing.T) {
 
 	for _, table := range tables {
 		result, err := ValidateFormat(table.expr)
-		if table.err != nil && table.err.Error() != err.Error() {
+		fmt.Println(table)
+		if err == nil && table.err != nil {
+			t.Errorf("validateFormat error failed in test %s, got: %v, want: %v.", table.name, err, table.err)
+		} else if table.err != nil && table.err.Error() != err.Error() {
 			t.Errorf("validateFormat error failed in test %s, got: %v, want: %v.", table.name, err, table.err)
 		} else if table.err == nil && !reflect.DeepEqual(result, table.result) {
 			t.Errorf("validateFormat failed in test %s, got: %v, want: %v.", table.name, result, table.result)

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -21,6 +21,7 @@ func TestValidateFormat(t *testing.T) {
 		{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
 		{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
 
+		{"success_when_digits_in_variable_no_space", "(a0==1  &&  b1==0 )", []string{"a0", "b1"}, nil},
 		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
 		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
 		{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -39,7 +39,6 @@ func TestValidateFormat(t *testing.T) {
 
 	for _, table := range tables {
 		result, err := ValidateFormat(table.expr)
-		fmt.Println(table)
 		if err == nil && table.err != nil {
 			t.Errorf("validateFormat error failed in test %s, got: %v, want: %v.", table.name, err, table.err)
 		} else if table.err != nil && table.err.Error() != err.Error() {

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -21,9 +21,9 @@ func TestValidateFormat(t *testing.T) {
 		{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
 		{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
 
-		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1 )", []string{"a-1", "b-0"}, nil},
+		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
 		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
-		{"success_when_pair_digits_in_variable", "(a_18_04 == 1 && b_20_10 == 1 )", []string{"a_18_04", "b_20_10"}, nil},
+		{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
 
 		{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
 		{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nytimes/go-compare-expressions
 go 1.14
 
 require (
-	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/Knetic/govaluate v3.0.0+incompatible
+	github.com/pkg/errors v0.9.1
 )


### PR DESCRIPTION
 Description

Before comparing a pair of expression strings, we would format the expression - which included removing the bool check (`== 0|1`) from the expression string, leaving only variables and bool operators. Then, checking that result string if there were any more =, 1, or 0 in string. 
So, this did not allow for potential variables that could have digits in them.

So the update in the PR is to allow for that exactly - do not error if variable has digits.

Fixes # (issue)
[DAPR-671](https://jira.nyt.net/browse/DAPR-671)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit testing
- [x] Manual testing

Please, view [this PR](https://github.com/nytimes/looking-glass-api/pull/212) in `looking-glass-api` on how to test manually.


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
