### PR TITLE
Feature/adt-6749: flex queries check if duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ go get github.com/nytimes/go-compare-expressions
 ```
 
 ## Usage
- To compare any two boolean/logical expression, call `AreDuplicateExpressions` method by passing the two expression that you want to compare.
+ To compare any two boolean/logical expression, call `CheckIfDuplicateExpressions` method by passing the two expression that you want to compare.
  ```go
     expr1 := "(foo == 1 && bar == 1) || baz = 0 " 
 	expr2 := "baz == 1 || bar == 1 && foo == 1"
-	result, err := AreDuplicateExpressions(expr1,expr2)
+	result, err := CheckIfDuplicateExpressions(expr1,expr2)
 ```
 
 ## Test

--- a/compare_expressions.go
+++ b/compare_expressions.go
@@ -75,7 +75,13 @@ func ValidateInput(expr1, expr2 string) ([]string, error) {
 		fmt.Printf("Error comparing lists")
 		return nil, err
 	}
-	return params1, nil
+
+	var finalParams []string
+	for _, p := range params1 {
+		finalParams = append(finalParams, strings.ReplaceAll(p, ".", "_"))
+	}
+
+	return finalParams, nil
 }
 
 /**
@@ -104,11 +110,11 @@ values or right side of expressions ----  to be binary only. So it can be 1 or 0
 attribute or left side of expression ---- can be any valid string name
 */
 func ValidateFormat(expr string) ([]string, error) {
-	regex := regexp.MustCompile(`\s*[=]{2}?\s*[1|0]`)
+	regex := regexp.MustCompile(`\s*[!=><]{2}?\s*[\d]`)
 	replaceExpr := regex.ReplaceAllString(expr, " ")
 	result := strings.Fields(replaceExpr)
 
-	invalidRegex := regexp.MustCompile(`\s+[1.0.=]{1}\s*`)
+	invalidRegex := regexp.MustCompile(`\s+[!=><\d]{1}\s*`)
 	invalidExpr := invalidRegex.MatchString(replaceExpr)
 	if invalidExpr {
 		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))
@@ -167,8 +173,10 @@ This function generates the truth table for the given expression and set of para
 It used tail recursion to evaluate expression for all possible values to the set of parameters.
 */
 func GenerateTruthTable(expr string, parameters []string, parametersMap map[string]interface{}, index int, count *[]bool) error {
+	separatRegex := regexp.MustCompile(`[.]`)
+	replexpr := separatRegex.ReplaceAllString(expr, "_")
 	if index == len(parameters) {
-		result, err := EvaluateExpression(expr, parametersMap)
+		result, err := EvaluateExpression(replexpr, parametersMap)
 		if err != nil {
 			fmt.Errorf("Unable to  evaluate expression, error: %v", err.Error())
 			return err

--- a/compare_expressions.go
+++ b/compare_expressions.go
@@ -117,7 +117,7 @@ func ValidateFormat(expr string) ([]string, error) {
 	invalidRegex := regexp.MustCompile(`\s+[!=><\d]{1}\s*`)
 	invalidExpr := invalidRegex.MatchString(replaceExpr)
 	if invalidExpr {
-		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))
+		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))
 	}
 
 	regex = regexp.MustCompile(`\s+&{2}?\s+`)

--- a/compare_expressions.go
+++ b/compare_expressions.go
@@ -110,14 +110,15 @@ values or right side of expressions ----  to be binary only. So it can be 1 or 0
 attribute or left side of expression ---- can be any valid string name
 */
 func ValidateFormat(expr string) ([]string, error) {
-	regex := regexp.MustCompile(`\s*[!=><]{2}?\s*[\d]`)
+	//  `\s*[!=><]{1}([!=><]?)\s*[\d]+`
+	regex := regexp.MustCompile(`\s*(>|<|==|!=|>=|<=){1}\s*[\d]+`)
 	replaceExpr := regex.ReplaceAllString(expr, " ")
 	result := strings.Fields(replaceExpr)
 
 	invalidRegex := regexp.MustCompile(`\s+[!=><\d]{1}\s*`)
 	invalidExpr := invalidRegex.MatchString(replaceExpr)
 	if invalidExpr {
-		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))
+		return nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))
 	}
 
 	regex = regexp.MustCompile(`\s+&{2}?\s+`)

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -15,27 +15,30 @@ func TestValidateFormat(t *testing.T) {
 		err    error
 	}{
 
-		{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
-		{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
-		{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
-		{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
-		{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
+		{"success_when_flex_expression_existing", "(crime == 1 && (entertainment_tv ==1 || movies == 1))", []string{"crime", "entertainment_tv", "movies"}, nil},
+		{"success_when_flex_expression", "(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))", []string{"firstparty.books_417", "topic.pvw_7d_fitness_320"}, nil},
 
-		{"success_when_digits_in_variable_no_space", "(a0==1  &&  b1==0 )", []string{"a0", "b1"}, nil},
-		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
-		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
-		{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
-
-		{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-
-		{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-
-		{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
-		{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
+		//{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
+		//{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
+		//{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
+		//{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
+		//{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
+		//
+		//{"success_when_digits_in_variable_no_space", "(a0==1  &&  b1==0 )", []string{"a0", "b1"}, nil},
+		//{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
+		//{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
+		//{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
+		//
+		//{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//
+		//{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
+		//
+		//{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
+		//{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
 	}
 
 	for _, table := range tables {
@@ -105,18 +108,32 @@ func TestCheckIfDuplicateExpressions(t *testing.T) {
 		result bool
 		err    error
 	}{
-		{"success_when_one_params", "a == 1", "a == 1", true, nil},
-		{"success_when_two_params", "a == 1 && b == 1", "b == 1 && a == 1", true, nil},
-		{"success_when_three_params", "a == 1 && b == 1 && c == 0", "b == 1 && a == 1 && c == 0", true, nil},
-		{"success_when_three_params", "a == 1 || b == 1 || c == 0", "b == 1 || a == 1 || c == 0", true, nil},
-		{"success_when_three_params", "a == 1 || b == 1 && c == 0", "c == 0 &&  b == 1 || a == 1", true, nil},
-		{"success_when_three_params", "(a == 1 || b == 1) && c == 0", "c == 0 &&  (b == 1 || a == 1)", true, nil},
-		{"success_when_three_params", "a == 1 || (b == 1 && c == 0)", "(c == 0 &&  b == 1) || a == 1", true, nil},
-		{"success_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 1 || c == 0 ) && (b == 1 || a == 1)", true, nil},
+		//{"success_with_og_flex_params",
+		//	"(crime == 1 && (entertainment_tv ==1 || movies == 1))",
+		//	"(crime == 1 && (entertainment_tv ==1 || movies == 1))",
+		//	true, nil},
+		{"success_with_flex_params_true",
+			"(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",
+			"(firstparty.books_417 == 1 || (topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_7d_baseball >= 1 || section.pvw_7d_sports >= 1))",
+			true, nil},
+		{"success_with_flex_params_false",
+			"(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 <= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",
+			"(firstparty.books_417 == 1 || (topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_7d_baseball >= 1 || section.pvw_7d_sports >= 1))",
+			false, nil},
 
-		{"error_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 || c == 0 ) && (b == 1 || a == 1)", false, nil},
 
-		{"error_when_diff_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 ) && (b == 1 || a == 1)", false, errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", []string{"a", "b", "c"}, []string{"a", "b"}))},
+		//{"success_when_one_params", "a == 1", "a == 1", true, nil},
+		//{"success_when_two_params", "a == 1 && b == 1", "b == 1 && a == 1", true, nil},
+		//{"success_when_three_params", "a == 1 && b == 1 && c == 0", "b == 1 && a == 1 && c == 0", true, nil},
+		//{"success_when_three_params", "a == 1 || b == 1 || c == 0", "b == 1 || a == 1 || c == 0", true, nil},
+		//{"success_when_three_params", "a == 1 || b == 1 && c == 0", "c == 0 &&  b == 1 || a == 1", true, nil},
+		//{"success_when_three_params", "(a == 1 || b == 1) && c == 0", "c == 0 &&  (b == 1 || a == 1)", true, nil},
+		//{"success_when_three_params", "a == 1 || (b == 1 && c == 0)", "(c == 0 &&  b == 1) || a == 1", true, nil},
+		//{"success_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 1 || c == 0 ) && (b == 1 || a == 1)", true, nil},
+		//
+		//{"error_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 || c == 0 ) && (b == 1 || a == 1)", false, nil},
+		//
+		//{"error_when_diff_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 ) && (b == 1 || a == 1)", false, errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", []string{"a", "b", "c"}, []string{"a", "b"}))},
 	}
 
 	for _, table := range tables {

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -14,7 +14,6 @@ func TestValidateFormat(t *testing.T) {
 		result []string
 		err    error
 	}{
-
 		{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
 		{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
 		{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
@@ -31,13 +30,13 @@ func TestValidateFormat(t *testing.T) {
 		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
 		{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
 
-		{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
-		{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
-		{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_operator_01", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
+		{"error_when_invalid_format_operator_02", "a !== 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
+		{"error_when_invalid_format_operator_03", "a ==> 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
 
-		{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
-		{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
-		{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_operator_pair_01", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
+		{"error_when_invalid_format_operator_pair_02", "a == 1 && b !== 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
+		{"error_when_invalid_format_operator_pair_02", "a == 00 && b ==> 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [==|!=|>|<|>=|<=] <digit>'"))},
 
 		{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
 		{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
@@ -119,7 +118,7 @@ func TestCheckIfDuplicateExpressions(t *testing.T) {
 		{"success_when_three_params_05", "a == 1 || (b == 1 && c == 0)", "(c == 0 &&  b == 1) || a == 1", true, nil},
 		{"success_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 1 || c == 0 ) && (b == 1 || a == 1)", true, nil},
 		{"success_when_one_flex_params", "firstparty.books_417 == 1", "firstparty.books_417 == 1", true, nil},
-		{"success_when_two_flex_params", "firstparty.books_417 != 1 && topic.pvw_7d_fitness_320 >= 1", "topic.pvw_7d_fitness_320 >= 1 && firstparty.books_417 != 1", true, nil},
+		{"success_when_two_flex_params", "firstparty.books_417 != 1 && topic.pvw_7d_fitness_320 > 1", "topic.pvw_7d_fitness_320 > 1 && firstparty.books_417 != 1", true, nil},
 		{"success_when_three_flex_params", "(firstparty.books_417 == 1 || topic.pvw_7d_fitness_320 >= 1) && c == 0", "c == 0 &&  (topic.pvw_7d_fitness_320 >= 1 || firstparty.books_417 == 1)", true, nil},
 		{"success_when_four_flex_params_true",
 			"(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",

--- a/compare_expressions_test.go
+++ b/compare_expressions_test.go
@@ -15,30 +15,32 @@ func TestValidateFormat(t *testing.T) {
 		err    error
 	}{
 
-		{"success_when_flex_expression_existing", "(crime == 1 && (entertainment_tv ==1 || movies == 1))", []string{"crime", "entertainment_tv", "movies"}, nil},
-		{"success_when_flex_expression", "(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))", []string{"firstparty.books_417", "topic.pvw_7d_fitness_320"}, nil},
+		{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
+		{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
+		{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
+		{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
+		{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
 
-		//{"success_when_simple_expression", "a == 1", []string{"a"}, nil},
-		//{"success_when_2_params", "a == 1 && b == 1", []string{"a", "b"}, nil},
-		//{"success_when_3_params", "a == 1 && b == 1 || c == 1", []string{"a", "b", "c"}, nil},
-		//{"success_when_2_params_with_brackets", "(a == 1 && b == 1 )", []string{"a", "b"}, nil},
-		//{"success_when_3_params_with_brackets", "(a == 1) && (b == 1 || c == 1)", []string{"a", "b", "c"}, nil},
-		//
-		//{"success_when_digits_in_variable_no_space", "(a0==1  &&  b1==0 )", []string{"a0", "b1"}, nil},
-		//{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
-		//{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
-		//{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
-		//
-		//{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//
-		//{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable == 1 or 0'"))},
-		//
-		//{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
-		//{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
+		{"success_when_1_flex_param", "firstparty.books_417 != 1", []string{"firstparty.books_417"}, nil},
+		{"success_when_3_flex_params", "firstparty.books_417 == 1 && topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 <= 5", []string{"firstparty.books_417", "topic.pvw_7d_fitness_320", "topic.pvw_30d_fitness_320"}, nil},
+		{"success_when_complex_flex_expression", "(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",
+			[]string{"firstparty.books_417", "topic.pvw_7d_fitness_320", "topic.pvw_30d_fitness_320", "section.pvw_7d_sports", "subsection.pvw_7d_baseball"}, nil},
+
+		{"success_when_digits_in_variable_no_space", "(a0==1  &&  b1==0 )", []string{"a0", "b1"}, nil},
+		{"success_when_one_digit_in_variable", "(a-1 == 1 && b-0 == 1)", []string{"a-1", "b-0"}, nil},
+		{"success_when_double_digits_in_variable", "(a_18 == 1 && b_20 == 1 )", []string{"a_18", "b_20"}, nil},
+		{"success_when_pair_digits_in_variable", "(a_18_04 == 1  && b_20_10  == 1)", []string{"a_18_04", "b_20_10"}, nil},
+
+		{"error_when_invalid_format_equals", "a === 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_ones", "a == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_zeroes", "a == 00", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+
+		{"error_when_invalid_format_equals_pair", "a == 1 && b ==== 1", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_ones_pair", "a == 1 && b == 11", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+		{"error_when_invalid_format_zeroes_pair", "a == 00 && b == 0", nil, errors.New(fmt.Sprintf("Invalid expression, Required Format 'variable [== | != | >= | <=] <digit>'"))},
+
+		{"error_when_invalid_format_ands", "a == 0 &&& b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
+		{"error_when_invalid_format_ors", "a == 0 |||| b == 1", nil, errors.New(fmt.Sprintf("Invalid expression, Allowed combinators && or ||"))},
 	}
 
 	for _, table := range tables {
@@ -108,32 +110,38 @@ func TestCheckIfDuplicateExpressions(t *testing.T) {
 		result bool
 		err    error
 	}{
-		//{"success_with_og_flex_params",
-		//	"(crime == 1 && (entertainment_tv ==1 || movies == 1))",
-		//	"(crime == 1 && (entertainment_tv ==1 || movies == 1))",
-		//	true, nil},
-		{"success_with_flex_params_true",
+		{"success_when_one_params", "a == 1", "a == 1", true, nil},
+		{"success_when_two_params", "a == 1 && b == 1", "b == 1 && a == 1", true, nil},
+		{"success_when_three_params_01", "a == 1 && b == 1 && c == 0", "b == 1 && a == 1 && c == 0", true, nil},
+		{"success_when_three_params_02", "a == 1 || b == 1 || c == 0", "b == 1 || a == 1 || c == 0", true, nil},
+		{"success_when_three_params_03", "a == 1 || b == 1 && c == 0", "c == 0 &&  b == 1 || a == 1", true, nil},
+		{"success_when_three_params_04", "(a == 1 || b == 1) && c == 0", "c == 0 &&  (b == 1 || a == 1)", true, nil},
+		{"success_when_three_params_05", "a == 1 || (b == 1 && c == 0)", "(c == 0 &&  b == 1) || a == 1", true, nil},
+		{"success_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 1 || c == 0 ) && (b == 1 || a == 1)", true, nil},
+		{"success_when_one_flex_params", "firstparty.books_417 == 1", "firstparty.books_417 == 1", true, nil},
+		{"success_when_two_flex_params", "firstparty.books_417 != 1 && topic.pvw_7d_fitness_320 >= 1", "topic.pvw_7d_fitness_320 >= 1 && firstparty.books_417 != 1", true, nil},
+		{"success_when_three_flex_params", "(firstparty.books_417 == 1 || topic.pvw_7d_fitness_320 >= 1) && c == 0", "c == 0 &&  (topic.pvw_7d_fitness_320 >= 1 || firstparty.books_417 == 1)", true, nil},
+		{"success_when_four_flex_params_true",
 			"(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",
 			"(firstparty.books_417 == 1 || (topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_7d_baseball >= 1 || section.pvw_7d_sports >= 1))",
 			true, nil},
-		{"success_with_flex_params_false",
-			"(firstparty.books_417 == 1 || (topic.pvw_7d_fitness_320 <= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1))",
-			"(firstparty.books_417 == 1 || (topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_7d_baseball >= 1 || section.pvw_7d_sports >= 1))",
+
+		{"error_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 || c == 0 ) && (b == 1 || a == 1)", false, nil},
+		{"error_when_four_flex_params_diff_operator",
+			"(topic.pvw_7d_fitness_320 <= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1)",
+			"(topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_7d_baseball >= 1 || section.pvw_7d_sports >= 1)",
+			false, nil},
+		{"error_when_four_flex_params_diff_pvw",
+			"(topic.pvw_7d_fitness_320 >= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || subsection.pvw_7d_baseball >= 1)",
+			"(topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1) && (subsection.pvw_30d_baseball >= 1 || section.pvw_7d_sports >= 1)",
 			false, nil},
 
-
-		//{"success_when_one_params", "a == 1", "a == 1", true, nil},
-		//{"success_when_two_params", "a == 1 && b == 1", "b == 1 && a == 1", true, nil},
-		//{"success_when_three_params", "a == 1 && b == 1 && c == 0", "b == 1 && a == 1 && c == 0", true, nil},
-		//{"success_when_three_params", "a == 1 || b == 1 || c == 0", "b == 1 || a == 1 || c == 0", true, nil},
-		//{"success_when_three_params", "a == 1 || b == 1 && c == 0", "c == 0 &&  b == 1 || a == 1", true, nil},
-		//{"success_when_three_params", "(a == 1 || b == 1) && c == 0", "c == 0 &&  (b == 1 || a == 1)", true, nil},
-		//{"success_when_three_params", "a == 1 || (b == 1 && c == 0)", "(c == 0 &&  b == 1) || a == 1", true, nil},
-		//{"success_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 1 || c == 0 ) && (b == 1 || a == 1)", true, nil},
-		//
-		//{"error_when_four_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 || c == 0 ) && (b == 1 || a == 1)", false, nil},
-		//
-		//{"error_when_diff_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 ) && (b == 1 || a == 1)", false, errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", []string{"a", "b", "c"}, []string{"a", "b"}))},
+		{"error_when_diff_params", "(a == 1 || b == 1 ) && (c == 0 || a == 1)", "(a == 0 ) && (b == 1 || a == 1)", false, errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", []string{"a", "b", "c"}, []string{"a", "b"}))},
+		{"error_when_diff_flex_params",
+			"(topic.pvw_7d_fitness_320 <= 1 || topic.pvw_30d_fitness_320 >= 1) && (section.pvw_7d_sports >= 1 || topic.pvw_7d_fitness_320 <= 1)",
+			"(topic.pvw_7d_fitness_320 <= 0 ) && (topic.pvw_30d_fitness_320 >= 1 || topic.pvw_7d_fitness_320 >= 1)",
+			false,
+			errors.New(fmt.Sprintf("expressions have different number of parameters, params1:%v , params2:%v", []string{"topic.pvw_7d_fitness_320", "topic.pvw_30d_fitness_320", "section.pvw_7d_sports"}, []string{"topic.pvw_7d_fitness_320", "topic.pvw_30d_fitness_320"}))},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
 ## Description

This adds support for checking duplicate queries against flex segment queries.

### Related PR
Please also review:
`looking-glass-api` PR: https://github.com/nytimes/looking-glass-api/pull/291

### Ticket 
https://jira.nyt.net/browse/ADT-6749


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

- [x] Unit testing
- [ ] Manual testing

### Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
